### PR TITLE
Fix incorrect namespaces and added symfony command as default

### DIFF
--- a/src/Cache/CheckEnvWhileWarmUp.php
+++ b/src/Cache/CheckEnvWhileWarmUp.php
@@ -2,7 +2,7 @@
 
 namespace Kennisnet\Env\Cache;
 
-use Env\EnvironmentVars;
+use Kennisnet\Env\EnvironmentVars;
 use Exception;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Command/CheckEnvVarsCommand.php
+++ b/src/Command/CheckEnvVarsCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kennisnet\Env\Command;
+
+use Kennisnet\Env\EnvironmentVars;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CheckEnvVarsCommand extends Command implements ContainerAwareInterface
+{
+    protected static $defaultName = 'app:check-env-vars';
+
+    /** @var ContainerInterface */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Check Env file and System defined values');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|void|null
+     * @throws \Doctrine\Common\Annotations\AnnotationException
+     * @throws \Kennisnet\Env\EnvironmentCheckException
+     * @throws \ReflectionException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var ValidatorInterface $validator */
+        $validator = $this->container->get('validator');
+        $report = EnvironmentVars::checkAppEnv($validator);
+        if (!$report->valid) {
+            $output->write((string)$report);
+            return 1; // Return error;
+        }
+    }
+}

--- a/src/DTO/AppEnv.php
+++ b/src/DTO/AppEnv.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Kennisnet\DTO;
+namespace Kennisnet\Env\DTO;
 
-use Env\Annotation\SecretValue;
+use Kennisnet\Env\Annotation\SecretValue;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 

--- a/src/EnvironmentVars.php
+++ b/src/EnvironmentVars.php
@@ -2,7 +2,7 @@
 
 namespace Kennisnet\Env;
 
-use Env\Annotation\SecretValue;
+use Kennisnet\Env\Annotation\SecretValue;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;


### PR DESCRIPTION
After implementing this some bugs bubbled up to the surface..

Incorrect namespaces and missing default Symfony command to validate the given envs files

